### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # use-action-state
 
+## DEPRECATED
+
+As of March 2024, [React has its own hook called `useActionState`](https://github.com/facebook/react/pull/28491) - it is recommended to use this instead of this library.
+
+---
+
 A react hook that simplifies usage of <a href="https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions">react server actions</a>. The hook adds error handing and loading states.
 
 ## Example


### PR DESCRIPTION
Hi @henninghall, thanks for making this library!

Quick PR to add a deprecation notice, now that React has its own `useActionState` hook